### PR TITLE
Add new failing test to match issue on apidoc.me

### DIFF
--- a/core/src/test/scala/core/OriginalValidatorSpec.scala
+++ b/core/src/test/scala/core/OriginalValidatorSpec.scala
@@ -1,0 +1,42 @@
+package core
+
+import _root_.builder.OriginalValidator
+import lib.ServiceConfiguration
+import com.bryzek.apidoc.api.v0.models.Original
+import com.bryzek.apidoc.api.v0.models.OriginalType.SwaggerJson
+import org.scalatest.{FunSpec, Matchers}
+
+class OriginalValidatorSpec
+    extends FunSpec
+    with Matchers{
+
+  private def readFile(path: String): String = {
+    scala.io.Source.fromFile(path).getLines.mkString("\n")
+  }
+
+  val config = ServiceConfiguration(
+    orgKey = "apidoc",
+    orgNamespace = "me.apidoc",
+    version = "0.0.2-dev"
+  )
+
+  describe("OriginalValidator") {
+
+    it("should validate valid swagger json") {
+      val filename = "refs.json"
+      val path = s"swagger/src/test/resources/$filename"
+      val result =
+        OriginalValidator(
+          config,
+          original = Original (
+            SwaggerJson,
+            readFile(path)
+          ),
+          new MockServiceFetcher()
+        ).validate
+
+    result.isRight should
+      be(true)
+    }
+  }
+}


### PR DESCRIPTION
I'm still seeing an issue with the swagger.json using refs. I've created a test to capture this error (which is currently failing).