### PR TITLE
361 apidoc can't validate Swagger with arrays in parameter list

### DIFF
--- a/core/src/test/resources/simple-w-array.json
+++ b/core/src/test/resources/simple-w-array.json
@@ -1,0 +1,43 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.0",
+        "title": "Simple API"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/test"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "test": {
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            }
+        }
+    }    
+}

--- a/core/src/test/resources/simple-without-array.json
+++ b/core/src/test/resources/simple-without-array.json
@@ -1,0 +1,40 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "0.0.0",
+        "title": "Simple API"
+    },
+    "paths": {
+        "/": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/test"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "test": {
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        }
+    }    
+}

--- a/core/src/test/scala/core/OriginalValidatorSpec.scala
+++ b/core/src/test/scala/core/OriginalValidatorSpec.scala
@@ -36,5 +36,20 @@ class OriginalValidatorSpec
         ).validate
     result.isRight should be(true)
     }
+
+    it("should validate valid swagger json without parameter of type array") {
+      val filename = "simple-without-array.json"
+      val path = s"core/src/test/resources/$filename"
+      val result =
+        OriginalValidator(
+          config,
+          original = Original (
+            SwaggerJson,
+            readFile(path)
+          ),
+          new MockServiceFetcher()
+        ).validate
+      result.isRight should be(true)
+    }
   }
 }

--- a/core/src/test/scala/core/OriginalValidatorSpec.scala
+++ b/core/src/test/scala/core/OriginalValidatorSpec.scala
@@ -22,9 +22,9 @@ class OriginalValidatorSpec
 
   describe("OriginalValidator") {
 
-    it("should validate valid swagger json") {
-      val filename = "refs.json"
-      val path = s"swagger/src/test/resources/$filename"
+    it("should validate valid swagger json with parameter of type array") {
+      val filename = "simple-w-array.json"
+      val path = s"core/src/test/resources/$filename"
       val result =
         OriginalValidator(
           config,
@@ -34,9 +34,7 @@ class OriginalValidatorSpec
           ),
           new MockServiceFetcher()
         ).validate
-
-    result.isRight should
-      be(true)
+    result.isRight should be(true)
     }
   }
 }

--- a/core/src/test/scala/core/OriginalValidatorSpec.scala
+++ b/core/src/test/scala/core/OriginalValidatorSpec.scala
@@ -1,0 +1,42 @@
+package core
+
+import _root_.builder.OriginalValidator
+import lib.ServiceConfiguration
+import com.bryzek.apidoc.api.v0.models.Original
+import com.bryzek.apidoc.api.v0.models.OriginalType.SwaggerJson
+import org.scalatest.{FunSpec, Matchers}
+
+class OriginalValidatorSpec
+    extends FunSpec
+    with Matchers{
+
+  private def readFile(path: String): String = {
+    scala.io.Source.fromFile(path).getLines.mkString("\n")
+  }
+
+  val config = ServiceConfiguration(
+    orgKey = "apidoc",
+    orgNamespace = "me.apidoc",
+    version = "0.0.2-dev"
+  )
+
+  describe("OriginalValidator") {
+
+    it("should validate valid swagger json") {
+      val filename = "refs.json"
+      val path = s"swagger/src/test/resources/$filename"
+      val result =
+        OriginalValidator(
+          config,
+          original = Original (
+            SwaggerJson,
+            readFile(path)
+          ),
+          new MockServiceFetcher()
+        ).validate
+
+    result.isRight should
+      be(true)
+    }
+  }
+}

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Field.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Field.scala
@@ -49,7 +49,6 @@ object Field {
 
       case p: ArrayProperty => {
         base.copy(
-          `type` = "[" + base.`type` + "]",
           description = Option(p.getUniqueItems()).getOrElse(false) match {
             case true => Util.combine(Seq(base.description, Some(s"Note: items are unique")))
             case false => base.description


### PR DESCRIPTION
- Add two tests and two jsons
  - One that contains an array of strings in the parameter list and fails to validate
  - One that contains a string in stead on an array of strings in the parameter list and successfully validates