### PR TITLE
Email authorization

### DIFF
--- a/api/app/actors/EmailActor.scala
+++ b/api/app/actors/EmailActor.scala
@@ -30,6 +30,7 @@ class EmailActor extends Actor {
       s"EmailActor.Messages.MembershipRequestCreated($guid)", {
         MembershipRequestsDao.findByGuid(Authorization.All, guid).map { request =>
           Emails.deliver(
+            context = Emails.Context.OrganizationAdmin,
             org = request.organization,
             publication = Publication.MembershipRequestsCreate,
             subject = s"${request.organization.name}: Membership Request from ${request.user.email}",
@@ -71,6 +72,7 @@ class EmailActor extends Actor {
       s"EmailActor.Messages.MembershipCreated($guid)", {
         MembershipsDao.findByGuid(Authorization.All, guid).map { membership =>
           Emails.deliver(
+            context = Emails.Context.OrganizationAdmin,
             org = membership.organization,
             publication = Publication.MembershipsCreate,
             subject = s"${membership.organization.name}: ${membership.user.email} has joined as ${membership.role}",
@@ -85,6 +87,7 @@ class EmailActor extends Actor {
         ApplicationsDao.findByGuid(Authorization.All, guid).map { application =>
           OrganizationsDao.findAll(Authorization.All, application = Some(application)).map { org =>
             Emails.deliver(
+              context = Emails.Context.OrganizationMember,
               org = org,
               publication = Publication.ApplicationsCreate,
               subject = s"${org.name}: New Application Created - ${application.name}",
@@ -115,6 +118,7 @@ class EmailActor extends Actor {
           ApplicationsDao.findAll(Authorization.All, version = Some(version), limit = 1).headOption.map { application =>
             OrganizationsDao.findAll(Authorization.All, application = Some(application), limit = 1).headOption.map { org =>
               Emails.deliver(
+                context = Emails.Context.Application(application),
                 org = org,
                 publication = Publication.VersionsCreate,
                 subject = s"${org.name}/${application.name}: Initial Version Uploaded (${version.version}) ",

--- a/api/app/actors/Emails.scala
+++ b/api/app/actors/Emails.scala
@@ -71,7 +71,7 @@ object Emails {
     }
   }
 
-  private[this] def isAuthorized(
+  private[actors] def isAuthorized(
     context: Context,
     organization: Organization,
     user: User

--- a/api/app/actors/Emails.scala
+++ b/api/app/actors/Emails.scala
@@ -59,9 +59,9 @@ object Emails {
         offset = offset
       )
     } { subscription =>
-      qualifies(context, organization, subscription.user) match {
+      isAuthorized(context, organization, subscription.user) match {
         case false => {
-          Logger.info(s"Emails: publication[$publication] subscription[$subscription] - does not qualify for context[$context]")
+          Logger.info(s"Emails: publication[$publication] subscription[$subscription] - not authorized for context[$context]. Skipping email")
         }
         case true => {
           Logger.info(s"Emails: delivering email for publication[$publication] subscription[$subscription]")
@@ -71,7 +71,7 @@ object Emails {
     }
   }
 
-  private[this] def qualifies(
+  private[this] def isAuthorized(
     context: Context,
     organization: Organization,
     user: User

--- a/api/app/actors/Emails.scala
+++ b/api/app/actors/Emails.scala
@@ -86,7 +86,8 @@ object Emails {
               case Some(_) => true
             }
           }
-          case Visibility.UNDEFINED(_) => {
+          case Visibility.UNDEFINED(name) => {
+            Logger.warn(s"Undefined visibility[$name] -- default behaviour assumes NOT AUTHORIZED")
             false
           }
         }

--- a/api/app/actors/Emails.scala
+++ b/api/app/actors/Emails.scala
@@ -36,7 +36,6 @@ object Emails {
     body: String
   ) {
     eachSubscription(context, org, publication, { subscription =>
-      Logger.info(s"Emails: delivering email for subscription[$subscription]")
       Email.sendHtml(
         to = Person(subscription.user),
         subject = subject,
@@ -61,8 +60,13 @@ object Emails {
       )
     } { subscription =>
       qualifies(context, organization, subscription.user) match {
-        case false => // No-op
-        case true => f(subscription)
+        case false => {
+          Logger.info(s"Emails: publication[$publication] subscription[$subscription] - does not qualify for context[$context]")
+        }
+        case true => {
+          Logger.info(s"Emails: delivering email for publication[$publication] subscription[$subscription]")
+          f(subscription)
+        }
       }
     }
   }

--- a/api/app/actors/TaskActor.scala
+++ b/api/app/actors/TaskActor.scala
@@ -131,6 +131,7 @@ class TaskActor extends Actor {
     ApplicationsDao.findAll(Authorization.All, version = Some(newVersion), limit = 1).headOption.map { application =>
       OrganizationsDao.findAll(Authorization.All, application = Some(application), limit = 1).headOption.map { org =>
         Emails.deliver(
+          context = Emails.Context.Application(application),
           org = org,
           publication = Publication.VersionsCreate,
           subject = s"${org.name}/${application.name}: New Version Uploaded (${newVersion.version}) ",

--- a/api/test/actors/EmailsSpec.scala
+++ b/api/test/actors/EmailsSpec.scala
@@ -1,0 +1,69 @@
+package actors
+
+import db.MembershipsDao
+import lib.Role
+import com.bryzek.apidoc.api.v0.models.Visibility
+import org.scalatest.{FunSpec, Matchers}
+import java.util.UUID
+
+class EmailsSpec extends FunSpec with Matchers with util.TestApplication {
+
+  describe("isAuthorized") {
+
+    lazy val org = db.Util.createOrganization()
+    lazy val randomUser = db.Util.createRandomUser()
+
+    lazy val orgMember = {
+      val user = db.Util.createRandomUser()
+      db.Util.createMembership(org, user, Role.Member)
+      user
+    }
+
+    lazy val orgAdmin = {
+      val user = db.Util.createRandomUser()
+      db.Util.createMembership(org, user, Role.Admin)
+      user
+    }
+
+    lazy val formerMember = {
+      val user = db.Util.createRandomUser()
+      val membership = db.Util.createMembership(org, user)
+      MembershipsDao.softDelete(user, membership)
+      user
+    }
+
+    it("Context.Application for private app") {
+      val app = db.Util.createApplication(org = org)
+      Emails.isAuthorized(Emails.Context.Application(app), org, randomUser) should be(false)
+      Emails.isAuthorized(Emails.Context.Application(app), org, orgMember) should be(true)
+      Emails.isAuthorized(Emails.Context.Application(app), org, formerMember) should be(false)
+    }
+
+    it("Context.Application for public app") {
+      val app = db.Util.createApplication(
+        org = org,
+        db.Util.createApplicationForm(visibility = Visibility.Public)
+      )
+
+      Emails.isAuthorized(Emails.Context.Application(app), org, randomUser) should be(true)
+      Emails.isAuthorized(Emails.Context.Application(app), org, orgMember) should be(true)
+      Emails.isAuthorized(Emails.Context.Application(app), org, formerMember) should be(true)
+    }
+
+    it("Context.OrganizationAdmin") {
+      Emails.isAuthorized(Emails.Context.OrganizationAdmin, org, randomUser) should be(false)
+      Emails.isAuthorized(Emails.Context.OrganizationAdmin, org, orgMember) should be(false)
+      Emails.isAuthorized(Emails.Context.OrganizationAdmin, org, orgAdmin) should be(true)
+      Emails.isAuthorized(Emails.Context.OrganizationAdmin, org, formerMember) should be(false)
+    }
+
+    it("Context.OrganizationMember") {
+      Emails.isAuthorized(Emails.Context.OrganizationMember, org, randomUser) should be(false)
+      Emails.isAuthorized(Emails.Context.OrganizationMember, org, orgMember) should be(true)
+      Emails.isAuthorized(Emails.Context.OrganizationMember, org, orgAdmin) should be(true)
+      Emails.isAuthorized(Emails.Context.OrganizationMember, org, formerMember) should be(false)
+    }
+
+  }
+
+}


### PR DESCRIPTION
 - Idea is to filter at email delivery time whether or not the particular
   user should receive that message. For example, if a user leaves an org,
   we should only send updates for public projects