### PR TITLE
Make history link more prominent

### DIFF
--- a/www/app/views/versions/show.scala.html
+++ b/www/app/views/versions/show.scala.html
@@ -13,6 +13,8 @@
         <a class="delete" data-confirm="Are you sure you want to delete version @{service.version}?" href="@routes.Versions.postDelete(orgKey = service.organization.key, applicationKey = service.application.key, version = service.version)">Delete this version</a> |
       }
 
+      <a href="@routes.HistoryController.index(org = Some(service.organization.key), app = Some(service.application.key))">History</a> |
+
       @if(isWatching) {
         <a class="postForm" href="@routes.Versions.postWatch(orgKey = service.organization.key, applicationKey = service.application.key, version = service.version)">Watching</a>
       } else {


### PR DESCRIPTION
I've noticed some people don't realize history is recorded.
However, history is an amazing feature!
Make it more prominent on the application version page
I opted to put it close to versioning/watching, as it is closely related
to those functions