### PR TITLE
Custom attributes

### DIFF
--- a/spec/spec.json
+++ b/spec/spec.json
@@ -279,9 +279,9 @@
 	    "description": "Allows for custom extension of apidoc. Custom attributes are made available to custom generators to allow extension for specific functionality",
 	    "fields": [
 		{ "name": "name", "type": "string" },
-		{ "name": "descrpition", "type": "string" },
+		{ "name": "descrpition", "type": "string", "required": false },
 		{ "name": "value", "type": "string" },
-		{ "name": "deprecation", "type": "deprecation" }
+		{ "name": "deprecation", "type": "deprecation", "required": false }
 	    ]
 	}
 

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -98,7 +98,8 @@
 		{ "name": "plural", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
-		{ "name": "values", "type": "[enum_value]" }
+		{ "name": "values", "type": "[enum_value]" },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -106,7 +107,8 @@
 	    "fields": [
 		{ "name": "name", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -116,7 +118,8 @@
 		{ "name": "plural", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
-		{ "name": "types", "type": "[union_type]", "minimum": 1, "description": "The names of the types that make up this union type" }
+		{ "name": "types", "type": "[union_type]", "minimum": 1, "description": "The names of the types that make up this union type" },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -125,7 +128,8 @@
 	    "fields": [
 		{ "name": "type", "type": "string", "description": "The name of a type (a primitive, model name, or enum name) that makes up this union type" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -135,7 +139,8 @@
 		{ "name": "plural", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
-		{ "name": "fields", "type": "[field]" }
+		{ "name": "fields", "type": "[field]" },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -149,7 +154,8 @@
 		{ "name": "required", "type": "boolean" },
 		{ "name": "minimum", "type": "long", "required": false },
 		{ "name": "maximum", "type": "long", "required": false },
-		{ "name": "example", "type": "string", "required": false }
+		{ "name": "example", "type": "string", "required": false },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -171,7 +177,8 @@
 		{ "name": "deprecation", "type": "deprecation", "required": false },
 		{ "name": "body", "type": "body", "required": false },
 		{ "name": "parameters", "type": "[parameter]", "default": "[]" },
-		{ "name": "responses", "type": "[response]", "default": "[]" }
+		{ "name": "responses", "type": "[response]", "default": "[]" },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -179,7 +186,8 @@
 	    "fields": [
 		{ "name": "type", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -194,7 +202,8 @@
 		{ "name": "default", "type": "string", "required": false },
 		{ "name": "minimum", "type": "long", "required": false },
 		{ "name": "maximum", "type": "long", "required": false },
-		{ "name": "example", "type": "string", "required": false }
+		{ "name": "example", "type": "string", "required": false },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -203,7 +212,8 @@
 		{ "name": "code", "type": "response_code" },
 		{ "name": "type", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -239,7 +249,8 @@
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
 		{ "name": "required", "type": "boolean" },
-		{ "name": "default", "type": "string", "required": false }
+		{ "name": "default", "type": "string", "required": false },
+		{ "name": "custom_attributes", "type": "[custom_attribute]" }
 	    ]
 	},
 
@@ -261,6 +272,16 @@
 	    "description": "Indicates that this particular element is considered deprecated in the API. See the description for details",
 	    "fields": [
 		{ "name": "description", "type": "string", "required": false }
+	    ]
+	},
+
+	"custom_attribute": {
+	    "description": "Allows for custom extension of apidoc. Custom attributes are made available to custom generators to allow extension for specific functionality",
+	    "fields": [
+		{ "name": "name", "type": "string" },
+		{ "name": "descrpition", "type": "string" },
+		{ "name": "value", "type": "string" },
+		{ "name": "deprecation", "type": "deprecation" }
 	    ]
 	}
 


### PR DESCRIPTION
This PR is just floating the idea of custom attributes. It's not intended to be merged. If the concept is approved I'd be happy to create a full PR.

We've started writing custom generators for our internal applications, in particular kafka producers and consumers. 

One thing we'd really like is "element_maximum" where we'd like the values in a [string] list to have validation for max length. Currently "maximum" would limit the size of the list not the length of it's items.

We're keen to get more info into the apidoc spec, however understand that it's not a great idea. So an ulternate would create dynamic custom attributes to the spec that we can control.

The above example:

```
      "fields": [
        {
          "name": "phone_numbers",
          "type": "[string]",
          "maximum": 5,
          "custom_attributes": [
            {
              "name": "element_maximum",
              "description": "max length of phone numbers",
              "value": "10"
            }
          ]
        }
      ]
```

Likewise we'd like to support some of our case classes extending base classes. Example:

```
  "models": {
    "person": {
      "fields": [
        ...
      ], 
      "custom_attributes": [
        {
          "name": "base_class",
          "value": "com.github.kalmanb.AmazingBaseEntity"
        }
      ]
    }
```
