### PR TITLE
Support for attributes

### DIFF
--- a/spec/spec.json
+++ b/spec/spec.json
@@ -278,10 +278,11 @@
 	},
 
 	"attribute": {
-	    "description": "Represents an additional attribute that is attached to one of the objects in apidoc. The main use case is to caprue additional metadata that doesn't necessarily define the API but aids in code generation. Examples would be hints for certain code generators about classes to extend, interfaces to implement, annotations to add, names to assign to certain methods, etc. The specific attributes will be applicable only in the context of the specific code generators usings them.",
+	    "description": "Represents an additional attribute that is attached to one of the objects in apidoc. The main use case is to capture additional metadata that doesn't necessarily define the API but aids in code generation. Examples would be hints for certain code generators about classes to extend, interfaces to implement, annotations to add, names to assign to certain methods, etc. The specific attributes will be applicable only in the context of the specific code generators usings them.",
 	    "fields": [
 		{ "name": "name", "type": "string" },
-		{ "name": "value", "type": "object" }
+		{ "name": "value", "type": "object" },
+		{ "name": "description", "type": "string", "required": false }
 	    ]
 	}
 

--- a/spec/spec.json
+++ b/spec/spec.json
@@ -98,7 +98,8 @@
 		{ "name": "plural", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
-		{ "name": "values", "type": "[enum_value]" }
+		{ "name": "values", "type": "[enum_value]" },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -106,7 +107,8 @@
 	    "fields": [
 		{ "name": "name", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -116,7 +118,8 @@
 		{ "name": "plural", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
-		{ "name": "types", "type": "[union_type]", "minimum": 1, "description": "The names of the types that make up this union type" }
+		{ "name": "types", "type": "[union_type]", "minimum": 1, "description": "The names of the types that make up this union type" },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -125,7 +128,8 @@
 	    "fields": [
 		{ "name": "type", "type": "string", "description": "The name of a type (a primitive, model name, or enum name) that makes up this union type" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -135,7 +139,8 @@
 		{ "name": "plural", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
-		{ "name": "fields", "type": "[field]" }
+		{ "name": "fields", "type": "[field]" },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -149,7 +154,8 @@
 		{ "name": "required", "type": "boolean" },
 		{ "name": "minimum", "type": "long", "required": false },
 		{ "name": "maximum", "type": "long", "required": false },
-		{ "name": "example", "type": "string", "required": false }
+		{ "name": "example", "type": "string", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -159,7 +165,8 @@
 		{ "name": "plural", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
-		{ "name": "operations", "type": "[operation]" }
+		{ "name": "operations", "type": "[operation]" },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -171,7 +178,8 @@
 		{ "name": "deprecation", "type": "deprecation", "required": false },
 		{ "name": "body", "type": "body", "required": false },
 		{ "name": "parameters", "type": "[parameter]", "default": "[]" },
-		{ "name": "responses", "type": "[response]", "default": "[]" }
+		{ "name": "responses", "type": "[response]", "default": "[]" },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -179,7 +187,8 @@
 	    "fields": [
 		{ "name": "type", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -194,7 +203,8 @@
 		{ "name": "default", "type": "string", "required": false },
 		{ "name": "minimum", "type": "long", "required": false },
 		{ "name": "maximum", "type": "long", "required": false },
-		{ "name": "example", "type": "string", "required": false }
+		{ "name": "example", "type": "string", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -203,7 +213,8 @@
 		{ "name": "code", "type": "response_code" },
 		{ "name": "type", "type": "string" },
 		{ "name": "description", "type": "string", "required": false },
-		{ "name": "deprecation", "type": "deprecation", "required": false }
+		{ "name": "deprecation", "type": "deprecation", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -239,7 +250,8 @@
 		{ "name": "description", "type": "string", "required": false },
 		{ "name": "deprecation", "type": "deprecation", "required": false },
 		{ "name": "required", "type": "boolean" },
-		{ "name": "default", "type": "string", "required": false }
+		{ "name": "default", "type": "string", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
 	    ]
 	},
 
@@ -260,7 +272,16 @@
 	"deprecation": {
 	    "description": "Indicates that this particular element is considered deprecated in the API. See the description for details",
 	    "fields": [
-		{ "name": "description", "type": "string", "required": false }
+		{ "name": "description", "type": "string", "required": false },
+		{ "name": "attributes", "type": "[attribute]", "default": "[]" }
+	    ]
+	},
+
+	"attribute": {
+	    "description": "Represents an additional attribute that is attached to one of the objects in apidoc. The main use case is to caprue additional metadata that doesn't necessarily define the API but aids in code generation. Examples would be hints for certain code generators about classes to extend, interfaces to implement, annotations to add, names to assign to certain methods, etc. The specific attributes will be applicable only in the context of the specific code generators usings them.",
+	    "fields": [
+		{ "name": "name", "type": "string" },
+		{ "name": "value", "type": "object" }
 	    ]
 	}
 


### PR DESCRIPTION
- Introduce concept of an attribute as a container to pass
  data directly into code generators
- General idea to support metadata 'hints' that aid code
  generation but do not really define the API
- Attached to all elements - following the design of the
  deprecation object
