### PR TITLE
Fix error w/ validation of generator keys

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,9 @@
+When syncing generators - do not assume the generators list will
+paginate. If the second fetch is same as first - just stop rather than
+inserting duplicate records.
+
+API changes - generate history of field reordering
+
 [warn] /web/apidoc/api/app/db/generators/ServicesDao.scala:118: method apply in trait WithResult is deprecated: Use [[fold]], [[foldWhile]] or [[withResult]] instead, which manages resources and memory
 [warn]       SQL(sql).on(bind: _*)().toList.map { fromRow(_) }.toSeq
 

--- a/api/app/actors/TaskActor.scala
+++ b/api/app/actors/TaskActor.scala
@@ -22,6 +22,8 @@ object TaskActor {
 
 class TaskActor extends Actor {
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   private[this] val NumberDaysBeforePurge = 90
 
   def receive = {
@@ -58,7 +60,7 @@ class TaskActor extends Actor {
           nOrFewerAttempts = Some(2),
           nOrMoreMinutesOld = Some(1)
         ).foreach { task =>
-          global.Actors.mainActor ! actors.MainActor.Messages.TaskCreated(task.guid)
+          _root_.global.Actors.mainActor ! actors.MainActor.Messages.TaskCreated(task.guid)
         }
       }
     )

--- a/api/app/controllers/GeneratorServices.scala
+++ b/api/app/controllers/GeneratorServices.scala
@@ -15,6 +15,8 @@ object GeneratorServices extends Controller with GeneratorServices
 trait GeneratorServices {
   this: Controller =>
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   def get(
     guid: Option[UUID],
     uri: Option[String],
@@ -73,10 +75,10 @@ trait GeneratorServices {
   def deleteByGuid(
     guid: UUID
   ) = Authenticated { request =>
-    println(s"deleteByGuid($guid)")
-    // TODO Authenticate
     ServicesDao.findByGuid(request.authorization, guid) match {
-      case None => NotFound
+      case None => {
+        NotFound
+      }
       case Some(service) => {
         // TODO: Generalize permission check
         if (service.audit.createdBy.guid == request.user.guid) {

--- a/schema/scripts/20151208-200931.sql
+++ b/schema/scripts/20151208-200931.sql
@@ -1,0 +1,1 @@
+create unique index generators_lower_key_un_idx on generators.generators(lower(key)) where deleted_at is null;


### PR DESCRIPTION
   - Fix duplicate key error when syncing generators
   - Do not assume that a generator paginates. This implementation
     does not depend on a blank generator set - and instead terminates
     if page size < limit