### PR TITLE
Validate types in a union are not imported

### DIFF
--- a/core/src/main/scala/core/builder/ServiceSpecValidator.scala
+++ b/core/src/main/scala/core/builder/ServiceSpecValidator.scala
@@ -12,20 +12,26 @@ case class ServiceSpecValidator(
 
   private val ReservedDiscriminatorValue = "value"
 
+  private val localTypeResolver = DatatypeResolver(
+    enumNames = service.enums.map(_.name),
+    modelNames = service.models.map(_.name),
+    unionNames = service.unions.map(_.name)
+  )
+  
   private val typeResolver = DatatypeResolver(
-    enumNames = service.enums.map(_.name) ++ service.imports.flatMap { service =>
+    enumNames = localTypeResolver.enumNames ++ service.imports.flatMap { service =>
       service.enums.map { enum =>
         s"${service.namespace}.enums.${enum}"
       }
     },
 
-    modelNames = service.models.map(_.name) ++ service.imports.flatMap { service =>
+    modelNames = localTypeResolver.modelNames ++ service.imports.flatMap { service =>
       service.models.map { model =>
         s"${service.namespace}.models.${model}"
       }
     },
 
-    unionNames = service.unions.map(_.name) ++ service.imports.flatMap { service =>
+    unionNames = localTypeResolver.unionNames ++ service.imports.flatMap { service =>
       service.unions.map { union =>
         s"${service.namespace}.unions.${union}"
       }
@@ -158,14 +164,40 @@ case class ServiceSpecValidator(
     val invalidTypes = service.unions.filter(!_.name.isEmpty).flatMap { union =>
       union.types.flatMap { t =>
         typeResolver.parse(t.`type`) match {
-          case None => Seq(s"Union[${union.name}] type[${t.`type`}] not found")
+          case None => {
+            Seq(s"Union[${union.name}] type[${t.`type`}] not found")
+          }
           case Some(t: Datatype) => {
+            // Validate that the type is NOT imported as there is
+            // no way we could retroactively modify the imported
+            // type to extend the union type that is only being
+            // defined in this service.
             t.`type` match {
               case Type(Kind.Primitive, "unit") => {
                 Seq("Union types cannot contain unit. To make a particular field optional, use the required property.")
               }
-              case _ => {
-                Seq.empty
+              case Type(Kind.Primitive, _) => {
+                Nil
+              }
+              case Type(Kind.Model, name) => {
+                service.models.find(_.name == name) match {
+                  case None => {
+                    Seq("TODO")
+                  }
+                  case Some(_) => {
+                    Nil
+                  }
+                }
+              }
+              case Type(Kind.Union, name) => {
+                service.unions.find(_.name == name) match {
+                  case None => {
+                    Seq("TODO")
+                  }
+                    case Some(_) => {
+                      Nil
+                    }
+                }
               }
             }
           }

--- a/core/src/test/scala/core/TestHelper.scala
+++ b/core/src/test/scala/core/TestHelper.scala
@@ -82,13 +82,14 @@ object TestHelper {
 
   def serviceValidatorFromApiJson(
     contents: String,
-    migration: VersionMigration = VersionMigration(internal = false)
+    migration: VersionMigration = VersionMigration(internal = false),
+    fetcher: MockServiceFetcher = new MockServiceFetcher()
   ): ServiceValidatorForSpecs = {
     TestServiceValidator(
       OriginalValidator(
         serviceConfig,
         Original(OriginalType.ApiJson, contents),
-        new MockServiceFetcher(),
+        fetcher,
         migration
       )
     )

--- a/core/src/test/scala/core/UnionTypeSpec.scala
+++ b/core/src/test/scala/core/UnionTypeSpec.scala
@@ -309,7 +309,7 @@ class UnionTypeSpec extends FunSpec with Matchers {
     fetcher.add(uri, validator.service)
 
     TestHelper.serviceValidatorFromApiJson(user, fetcher = fetcher).errors should be(
-      Seq("Union[expandable user] type[test.common] is invalid. Cannot use an imported type as part of a union as there is no way to declare that the imported type expands the union type defined here.")
+      Seq("Union[expandable_user] type[test.common.models.reference] is invalid. Cannot use an imported type as part of a union as there is no way to declare that the imported type expands the union type defined here.")
     )
 
   }


### PR DESCRIPTION
  - this avoids a race condition where, for example:

     - service "common" defines a model named reference
     - service "user" imports common and defines a union named "user_union" of types "user" and "common.reference"

The problem is that the code generation for common.reference occurs BEFORE user and thus in typed languages where we want to annotate that the Reference class extends UserUnion - we cannot as at the time of code generation for the Reference class we do not know that the union type "user_union" exists.