### PR TITLE
validate optional attributes

### DIFF
--- a/core/src/main/scala/core/builder/api_json/InternalServiceForm.scala
+++ b/core/src/main/scala/core/builder/api_json/InternalServiceForm.scala
@@ -97,6 +97,7 @@ private[api_json] case class InternalServiceForm(
                 optionalBooleans = Seq("required"),
                 optionalObjects = Seq("deprecation"),
                 optionalStrings = Seq("default", "description"),
+                optionalArraysOfObjects = Seq("attributes"),
                 prefix = Some(s"Header[${headerName.getOrElse("")}]".trim)
               )
             )
@@ -378,6 +379,7 @@ object InternalUnionForm {
                  strings = Seq("type"),
                  optionalStrings = Seq("description"),
                  optionalObjects = Seq("deprecation"),
+                 optionalArraysOfObjects = Seq("attributes"),
                  prefix = Some(s"Union[$name] type[${typeName.getOrElse("")}]")
                )
              )
@@ -399,6 +401,7 @@ object InternalUnionForm {
         optionalStrings = Seq("discriminator", "description", "plural"),
         arraysOfObjects = Seq("types"),
         optionalObjects = Seq("deprecation"),
+        optionalArraysOfObjects = Seq("attributes"),
         prefix = Some(s"Union[$name]")
       )
     )
@@ -477,6 +480,7 @@ object InternalEnumForm {
                  strings = Seq("name"),
                  optionalStrings = Seq("description"),
                  optionalObjects = Seq("deprecation"),
+                 optionalArraysOfObjects = Seq("attributes"),
                  prefix = Some(s"Enum[$name] value[${valueName.getOrElse("")}]")
                )
              )
@@ -497,6 +501,7 @@ object InternalEnumForm {
         optionalStrings = Seq("name", "description", "plural"),
         arraysOfObjects = Seq("values"),
         optionalObjects = Seq("deprecation"),
+        optionalArraysOfObjects = Seq("attributes"),
         prefix = Some(s"Enum[$name]")
       )
     )
@@ -553,7 +558,8 @@ object InternalResourceForm {
         value,
         optionalStrings = Seq("path", "description"),
         optionalObjects = Seq("deprecation"),
-        arraysOfObjects = Seq("operations")
+        arraysOfObjects = Seq("operations"),
+        optionalArraysOfObjects = Seq("attributes")
       )
     )
   }
@@ -613,7 +619,8 @@ object InternalOperationForm {
           o,
           strings = Seq("type"),
           optionalStrings = Seq("description"),
-          optionalObjects = Seq("deprecation")
+          optionalObjects = Seq("deprecation"),
+          optionalArraysOfObjects = Seq("attributes")
         )
       )
     }
@@ -632,7 +639,7 @@ object InternalOperationForm {
         json,
         strings = Seq("method"),
         optionalStrings = Seq("description", "path"),
-        optionalArraysOfObjects = Seq("parameters"),
+        optionalArraysOfObjects = Seq("parameters", "attributes"),
         optionalObjects = Seq("body", "responses", "deprecation")
       )
     )

--- a/core/src/test/scala/core/ServiceValidatorSpec.scala
+++ b/core/src/test/scala/core/ServiceValidatorSpec.scala
@@ -213,6 +213,39 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
     TestHelper.serviceValidatorFromApiJson(json.format("unknown_model")).errors.mkString("") should be("Resource[user] GET /users/:guid response code[200] has an invalid type[unknown_model].")
   }
 
+  it("operations w/ a valid attributes validates correct") {
+    val json = """
+    {
+      "name": "Api Doc",
+      "apidoc": { "version": "0.9.6" },
+      "models": {
+        "user": {
+          "fields": [
+            { "name": "guid", "type": "string" }
+          ]
+        }
+      },
+      "resources": {
+        "user": {
+          "operations": [
+            {
+              "method": "GET",
+              "attributes": [
+                {
+                  "name": "sample",
+                  "value": {}
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+    """
+
+    TestHelper.serviceValidatorFromApiJson(json).errors.mkString("") should be("")
+  }
+
   it("includes path parameter in operations") {
     val json = """
     {


### PR DESCRIPTION
Apidoc models (i.e. Operation - https://github.com/mbryzek/apidoc/blob/master/generated%2Fapp%2FBryzekApidocSpecV0Client.scala#L145) allow for an optional "attributes" field, but uploading a spec with this field results in the following error:

```sh
 - Resource[view] GET /<sample_path> Unrecognized element[attributes]
```

A few models are currently validating "attributes" (i.e. https://github.com/mbryzek/apidoc/blob/master/core%2Fsrc%2Fmain%2Fscala%2Fcore%2Fbuilder%2Fapi_json%2FInternalServiceForm.scala#L451)

Similar validation has been added to the remaining models that include an optional "attributes" field.