### PR TITLE
Support additional formats in Swagger import

### DIFF
--- a/swagger/src/main/scala/me/apidoc/swagger/SchemaType.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/SchemaType.scala
@@ -11,12 +11,14 @@ object SchemaType {
     SchemaType("int32", "integer"),
     SchemaType("int64", "long"),
     SchemaType("float", "double"),
+    SchemaType("decimal", "decimal"),
     SchemaType("double", "double"),
     SchemaType("string", "string"),
     SchemaType("byte", "string"), // TODO: apidoc needs support for byte
     SchemaType("boolean", "boolean"),
     SchemaType("date", "date-iso8601"),
-    SchemaType("dateTime", "date-time-iso8601")
+    SchemaType("dateTime", "date-time-iso8601"),
+    SchemaType("uuid", "uuid")
   )
 
   def fromSwagger(

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/SchemaType.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/SchemaType.scala
@@ -11,12 +11,14 @@ object SchemaType {
     SchemaType("int32", "integer"),
     SchemaType("int64", "long"),
     SchemaType("float", "double"),
+    SchemaType("decimal", "decimal"),
     SchemaType("double", "double"),
     SchemaType("string", "string"),
     SchemaType("byte", "string"), // TODO: apidoc needs support for byte
     SchemaType("boolean", "boolean"),
     SchemaType("date", "date-iso8601"),
-    SchemaType("dateTime", "date-time-iso8601")
+    SchemaType("dateTime", "date-time-iso8601"),
+    SchemaType("uuid", "uuid")
   )
 
   def fromSwagger(

--- a/swagger/src/test/resources/petstore-with-external-docs.json
+++ b/swagger/src/test/resources/petstore-with-external-docs.json
@@ -194,6 +194,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "guid": {
+          "type": "string",
+          "format": "uuid"
+        },
         "name": {
           "type": "string"
         },

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
@@ -83,6 +83,11 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                       required = true
                     ),
                     Field(
+                      name = "guid",
+                      `type` = "uuid",
+                      required = false
+                    ),
+                    Field(
                       name = "name",
                       `type` = "string",
                       required = true
@@ -106,6 +111,11 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                     Field(
                       name = "id",
                       `type` = "long",
+                      required = false
+                    ),
+                    Field(
+                      name = "guid",
+                      `type` = "uuid",
                       required = false
                     ),
                     Field(


### PR DESCRIPTION
Swagger doesn't support these, but Apidoc does - no reason to block them.