### PR TITLE
Fix bug with multiple paramters in the path

### DIFF
--- a/swagger/src/main/scala/me/apidoc/swagger/Util.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/Util.scala
@@ -28,7 +28,7 @@ object Util {
     name.trim
   }
 
-  private val PathParams = """\{(.+)\}""".r
+  private val PathParams = """\{(.+?)\}""".r
 
   /**
     * Replace swagger {...} syntax with leading :

--- a/swagger/src/test/resources/petstore-with-external-docs-and-complex-path.json
+++ b/swagger/src/test/resources/petstore-with-external-docs-and-complex-path.json
@@ -31,7 +31,7 @@
     "application/json"
   ],
   "paths": {
-    "/store/pets/{product_code}": {
+    "/store/{store_id}/pets/{product_code}": {
       "get": {
         "description": "Returns all pets from the system matching product code that the user has access to",
         "operationId": "findPets",
@@ -46,6 +46,14 @@
           "text/html"
         ],
         "parameters": [
+          {
+            "name": "store_id",
+            "in": "path",
+            "description": "The id of the store housing the pet(s).",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
           {
             "name": "product_code",
             "in": "path",

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
@@ -195,6 +195,149 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
       }
     }
 
+    it("should parse petstore-with-external-docs-and-complex-path.json") {
+      val files = Seq("petstore-with-external-docs-and-complex-path.json")
+      files.foreach {
+        filename =>
+          val path = s"swagger/src/test/resources/$filename"
+          println(s"Reading file[$path]")
+          SwaggerServiceValidator(config, readFile(path)).validate match {
+            case Left(errors) => {
+              fail(s"Service validation failed for path[$path]: " + errors.mkString(", "))
+            }
+            case Right(service) => {
+              service.name should be("Swagger Petstore")
+              service.namespace should be("me.apidoc.swagger.petstore.v0")
+              service.organization.key should be("apidoc")
+              service.application.key should be("swagger-petstore")
+              service.version should be("0.0.2-dev")
+              service.baseUrl should be(Some("http://petstore.swagger.wordnik.com/api"))
+              service.description should be(Some("A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification"))
+              service.headers should be(Seq.empty)
+              service.imports should be(Seq.empty)
+              service.enums should be(Seq.empty)
+              service.models.map(_.name).sorted should be(Seq("errorModel", "newPet", "pet"))
+
+              checkModel(
+                service.models.find(_.name == "pet").get,
+                Model(
+                  name = "pet",
+                  plural = "pets",
+                  description = Some("find more info here: https://helloreverb.com/about"),
+                  fields = Seq(
+                    Field(
+                      name = "id",
+                      `type` = "long",
+                      required = true
+                    ),
+                    Field(
+                      name = "name",
+                      `type` = "string",
+                      required = true
+                    ),
+                    Field(
+                      name = "tag",
+                      `type` = "string",
+                      required = false
+                    )
+                  )
+                )
+              )
+
+              checkModel(
+                service.models.find(_.name == "newPet").get,
+                Model(
+                  name = "newPet",
+                  plural = "newPets",
+                  description = Some("find more info here: https://helloreverb.com/about"),
+                  fields = Seq(
+                    Field(
+                      name = "id",
+                      `type` = "long",
+                      required = false
+                    ),
+                    Field(
+                      name = "name",
+                      `type` = "string",
+                      required = true
+                    ),
+                    Field(
+                      name = "tag",
+                      `type` = "string",
+                      required = false
+                    )
+                  )
+                )
+              )
+
+              checkModel(
+                service.models.find(_.name == "errorModel").get,
+                Model(
+                  name = "errorModel",
+                  plural = "errorModels",
+                  description = None,
+                  fields = Seq(
+                    Field(
+                      name = "code",
+                      `type` = "integer",
+                      required = true
+                    ),
+                    Field(
+                      name = "message",
+                      `type` = "string",
+                      required = true
+                    )
+                  )
+                )
+              )
+
+              service.resources.filter(_.`type` == "pet").flatMap(_.operations.map(_.path)).toSet shouldBe Set(
+                "/pets/:id",
+                "/store/:store_id/pets/:product_code"
+              )
+
+              service.resources.foreach {
+                r =>
+                  println(s" Resource ${r.`type`}")
+                  r.operations.foreach {
+                    op =>
+                      println(s"  ${op.method} ${op.path}")
+
+                      println(s"   body:")
+                      op.body match {
+                        case None => {
+                          println("    none")
+                        }
+                        case Some(b) => {
+                          println(s"    ${b.`type`}")
+                        }
+                      }
+
+                      println(s"   parameters:")
+                      op.parameters match {
+                        case Nil => {
+                          println("    none")
+                        }
+                        case params => {
+                          params.foreach {
+                            p =>
+                              println(s"    ${p.name}: ${p.`type`} (${p.location}) ${printRequired(p.required)}")
+                          }
+                        }
+                      }
+
+                      println(s"   responses:")
+                      op.responses.foreach {
+                        r =>
+                          println(s"    ${r.code}: ${r.`type`}")
+                      }
+                  }
+              }
+            }
+          }
+      }
+    }
+
     it("should parse refs.json") {
       val files = Seq("refs.json")
       files.foreach {


### PR DESCRIPTION
In the test example,

```
/store/{store_id}/pets/{product_code}
```

was showing up in apidoc as

```
/store/:store_id}/pets/{product_code
```

but should have been

```
/store/:store_id/pets/:product_code
```