### PR TITLE
upgrade com.sendgrid.sendgrid-java 2.2.2=>3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val api = project
       "com.typesafe.play" %% "anorm"         % "2.5.0",
       "org.postgresql"    %  "postgresql"    % "9.4.1208",
       "org.mindrot"       %  "jbcrypt"       % "0.3m",
-      "com.sendgrid"      %  "sendgrid-java" % "2.2.2",
+      "com.sendgrid"      %  "sendgrid-java" % "3.0.0",
       specs2              %  Test,
       "org.scalatestplus" %% "play" % "1.4.0" % "test"
     )


### PR DESCRIPTION
SendGrid 3.0.0 Upgrade

V3 API Reference: 
https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html

V3 Java Client and API Usage Example:
https://github.com/sendgrid/sendgrid-java#quick-start
