### PR TITLE
Remove check for duplicate resources

### DIFF
--- a/core/src/main/scala/core/builder/ServiceSpecValidator.scala
+++ b/core/src/main/scala/core/builder/ServiceSpecValidator.scala
@@ -433,16 +433,7 @@ case class ServiceSpecValidator(
       s"Resource[${resource.`type`}] must have at least one operation"
     }
 
-    val duplicateModels = service.resources.flatMap { resource =>
-      val numberResources = service.resources.filter { _.`type` == resource.`type` }.size
-      if (numberResources <= 1) {
-        None
-      } else {
-        Some(s"Resource[${resource.`type`}] cannot appear multiple times")
-      }
-    }.distinct
-
-    datatypeErrors ++ missingOperations ++ duplicateModels
+    datatypeErrors ++ missingOperations
   }
 
   private def validateParameterLocations(): Seq[String] = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,4 +9,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")


### PR DESCRIPTION
- No reason why a user cannot choose to provide two sections for each resource
  - Ultimately paths are important which are already enforced