### PR TITLE
Remove period (".") characters from url keys, as they break onclick events

### DIFF
--- a/lib/src/main/scala/UrlKey.scala
+++ b/lib/src/main/scala/UrlKey.scala
@@ -5,7 +5,7 @@ object UrlKey {
   private val MinKeyLength = 3
 
   // Only want lower case letters and dashes
-  private val Regexp1 = """([^0-9a-z\-\_\.])""".r
+  private val Regexp1 = """([^0-9a-z\-\_])""".r
 
   // Turn multiple dashes into single dashes
   private val Regexp2 = """(\-+)""".r


### PR DESCRIPTION
For example see http://www.apidoc.me/bryzek/apidoc-api/latest
com.bryzek.apidoc.generator.v0.models.healthcheck resource
the GET operations can't be expanded