### PR TITLE
Import in documentation should link to documentation instead of service.json

### DIFF
--- a/www/app/views/versions/imports.scala.html
+++ b/www/app/views/versions/imports.scala.html
@@ -4,7 +4,7 @@
   <tbody>
    @imports.map { imp =>
      <tr>
-       <td><a href="@imp.uri">@imp.uri</a></td>
+       <td><a href="@imp.uri.reverse.dropWhile(_ != '/').drop(1).reverse">@imp.uri</a></td>
      </tr>
    }
   </tbody>


### PR DESCRIPTION
Instead of linking to e.g
`http://www.apidoc.me/bryzek/apidoc-common/latest/service.json`, the
documentation should link to the documentation of the linked model, ie.
to `http://www.apidoc.me/bryzek/apidoc-common/latest`