### PR TITLE
Imported model types are displayed with wrong version

### DIFF
--- a/www/app/lib/TypeLabel.scala
+++ b/www/app/lib/TypeLabel.scala
@@ -97,7 +97,7 @@ case class TypeLabel(
 
   private[this] def importLink(imp: Import, kind: String, shortName: String, fullName: String): String = {
     Href(
-      s"$fullName:$version",
+      s"$fullName:${imp.version}",
       Href.prefix(imp.organization.key, imp.application.key, imp.version) + s"#$kind-${UrlKey.generate(shortName)}"
     ).html
   }


### PR DESCRIPTION
Instead of the version of the imported model, the type is displayed with
the version of the importing model.