### PR TITLE
Relax plural check to resources only

### DIFF
--- a/core/src/main/scala/core/builder/ServiceSpecValidator.scala
+++ b/core/src/main/scala/core/builder/ServiceSpecValidator.scala
@@ -113,9 +113,7 @@ case class ServiceSpecValidator(
 
     val duplicates = dupsError("Model", service.models.map(_.name))
 
-    val duplicatePlurals = dupsError("Model with plural", service.models.map(_.plural))
-
-    nameErrors ++ fieldErrors ++ duplicates ++ duplicatePlurals
+    nameErrors ++ fieldErrors ++ duplicates
   }
 
   private def validateEnums(): Seq[String] = {
@@ -444,7 +442,9 @@ case class ServiceSpecValidator(
       }
     }.distinct
 
-    datatypeErrors ++ missingOperations ++ duplicateModels
+    val duplicatePlurals = dupsError("Resource with plural", service.resources.map(_.plural))
+
+    datatypeErrors ++ missingOperations ++ duplicateModels ++ duplicatePlurals
   }
 
   private def validateParameterLocations(): Seq[String] = {

--- a/core/src/test/scala/core/ServiceValidatorSpec.scala
+++ b/core/src/test/scala/core/ServiceValidatorSpec.scala
@@ -543,7 +543,7 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
 
   }
 
-  it("model with duplicate plural names") {
+  it("model with duplicate plural names are allowed as long as not exposed as resources") {
     val json =
       """
     {
@@ -561,10 +561,62 @@ class ServiceValidatorSpec extends FunSpec with Matchers {
             { "name": "id", "type": "string" }
           ]
         }
+      },
+      "resources": {
+        "user": {
+          "operations": [
+            {
+              "method": "GET"
+            }
+          ]
+        }
       }
     }
     """
+
     val validator = TestHelper.serviceValidatorFromApiJson(json)
-    validator.errors.mkString("") should be("Model with plural[users] appears more than once")
+    validator.errors.mkString("") should be("")
+  }
+
+  it("resources with duplicate plural names are NOT allowed") {
+        val json =
+      """
+    {
+      "name": "Api Doc",
+      "models": {
+        "user": {
+          "plural": "users",
+          "fields": [
+            { "name": "id", "type": "string" }
+          ]
+        },
+        "person": {
+          "plural": "users",
+          "fields": [
+            { "name": "id", "type": "string" }
+          ]
+        }
+      },
+      "resources": {
+        "user": {
+          "operations": [
+            {
+              "method": "GET"
+            }
+          ]
+        },
+        "person": {
+          "operations": [
+            {
+              "method": "GET"
+            }
+          ]
+        }
+      }
+    }
+    """
+
+    val validator = TestHelper.serviceValidatorFromApiJson(json)
+    validator.errors.mkString("") should be("Resource with plural[users] appears more than once")
   }
 }


### PR DESCRIPTION
- too strict for models - and only care about plurals when exposing as resources