### PR TITLE
Fixes #607. ServiceSpecValidator errors on some param enum edge cases.

### DIFF
--- a/swagger/src/main/scala/me/apidoc/swagger/Util.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/Util.scala
@@ -125,24 +125,28 @@ object Util {
   }
 
   def buildPropertyEnumTypeName(modelName: String, enumName: String) = {
-    List(modelName, enumName).map(camelCaseInitialCapitalized(_)).mkString
+    List(modelName, enumName).map(_.capitalize).mkString
   }
 
   def buildParamEnumTypeName(resourceName: String, param: swaggerparams.Parameter, method: String): String = {
     param match {
       case qp: swaggerparams.QueryParameter =>
-        List(resourceName, qp.getName, method, "Query").map(camelCaseInitialCapitalized(_)).mkString
+        formatName(resourceName, qp.getName, method, "Query")
       case pp: swaggerparams.PathParameter =>
-        List(resourceName, pp.getName, method, "Path").map(camelCaseInitialCapitalized(_)).mkString
+        formatName(resourceName, pp.getName, method, "Path")
       case _ =>
         sys.error(s"Enumerations not supported for swagger parameters of type ${param.getClass}")
     }
   }
 
+  def formatName(resourceName: String, paramName: String, method: String, location: String) = {
+    List(
+      resourceName,
+      paramName.capitalize,
+      method.toLowerCase.capitalize,
+      location.capitalize).mkString
+  }
+
   def retrieveMethod(operation: swaggermodels.Operation, path: swaggermodels.Path): Option[swaggermodels.HttpMethod] =
     path.getOperationMap().find(_._2 == operation).map(_._1)
-
-  def camelCaseInitialCapitalized(s: String): String = s.toLowerCase.capitalize
-
-
 }

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Operation.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Operation.scala
@@ -9,6 +9,7 @@ object Operation {
 
   def apply(
     resolver: Resolver,
+    modelName: String,
     method: apidoc.Method,
     url: String,
     op: io.swagger.models.Operation
@@ -19,7 +20,7 @@ object Operation {
     val parameters = Util.toArray(op.getParameters).flatMap { param =>
       param match {
         case p: BodyParameter => None
-        case _ => Some(Parameter(resolver, url, method, param))
+        case _ => Some(Parameter(resolver, modelName, method, param))
       }
     }
 

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Parameter.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Parameter.scala
@@ -9,7 +9,7 @@ object Parameter {
 
   def apply(
     resolver: Resolver,
-    url: String,
+    modelName: String,
     method: apidoc.Method,
     param: swaggerparams.Parameter
   ): apidoc.Parameter = {
@@ -49,17 +49,15 @@ object Parameter {
         toSchemaType(resolver, p, Option(p.getItems))
       }
       case p: swaggerparams.PathParameter => {
-        if(Util.hasStringEnum(p)) {
-          val resourceName = resolver.findModelByUrl(url).map(_.name).getOrElse("")
-          SchemaDetails(`type` = Util.buildParamEnumTypeName(resourceName, p, method.toString))
+        if(Util.hasStringEnum(p)){
+          SchemaDetails(`type` = Util.buildParamEnumTypeName(modelName, p, method.toString))
         } else {
           toSchemaType(resolver, p, Option(p.getItems))
         }
       }
       case p: swaggerparams.QueryParameter => {
         if(Util.hasStringEnum(p)) {
-          val resourceName = resolver.findModelByUrl(url).map(_.name).getOrElse("")
-          SchemaDetails(`type` = Util.buildParamEnumTypeName(resourceName, p, method.toString))
+          SchemaDetails(`type` = Util.buildParamEnumTypeName(modelName, p, method.toString))
         } else {
           toSchemaType(resolver, p, Option(p.getItems))
         }

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Resource.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Resource.scala
@@ -14,7 +14,6 @@ object Resource {
   ): apidoc.Resource = {
     // getVendorExtensions
     // getParameters
-
     apidoc.Resource(
       `type` = model.name,
       plural = model.plural,
@@ -22,12 +21,12 @@ object Resource {
       description = None,
       deprecation = None,
       operations = Seq(
-        Option(path.getGet).map { Operation(resolver, apidoc.Method.Get, url, _) },
-        Option(path.getPost).map { Operation(resolver, apidoc.Method.Post, url, _) },
-        Option(path.getPut).map { Operation(resolver, apidoc.Method.Put, url, _) },
-        Option(path.getDelete).map { Operation(resolver, apidoc.Method.Delete, url, _) },
-        Option(path.getOptions).map { Operation(resolver, apidoc.Method.Options, url, _) },
-        Option(path.getPatch).map { Operation(resolver, apidoc.Method.Patch, url, _) }
+        Option(path.getGet).map { Operation(resolver, model.name, apidoc.Method.Get, url, _) },
+        Option(path.getPost).map { Operation(resolver, model.name, apidoc.Method.Post, url, _) },
+        Option(path.getPut).map { Operation(resolver, model.name, apidoc.Method.Put, url, _) },
+        Option(path.getDelete).map { Operation(resolver, model.name, apidoc.Method.Delete, url, _) },
+        Option(path.getOptions).map { Operation(resolver, model.name, apidoc.Method.Options, url, _) },
+        Option(path.getPatch).map { Operation(resolver, model.name, apidoc.Method.Patch, url, _) }
       ).flatten
     )
   }

--- a/swagger/src/test/resources/petstore-enums.json
+++ b/swagger/src/test/resources/petstore-enums.json
@@ -52,6 +52,29 @@
             }
           }
         }
+      },
+      "delete": {
+        "summary": "delete pets by status - as a path param",
+        "parameters":[
+          {
+            "name":"status",
+            "in":"path",
+            "required":true,
+            "type":"string",
+            "enum":["available", "pending", "sold"]
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pets deleted - no response body content"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
       }
     },
     "/pets/": {

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
@@ -1,6 +1,6 @@
 package me.apidoc.swagger
 
-import com.bryzek.apidoc.spec.v0.models.Method.Get
+import com.bryzek.apidoc.spec.v0.models.Method.{Delete, Get}
 import com.bryzek.apidoc.spec.v0.models.ParameterLocation.{Path, Query}
 import com.bryzek.apidoc.spec.v0.models.{EnumValue, _}
 import lib.ServiceConfiguration
@@ -195,12 +195,43 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                           description = Some("unexpected error"),
                           deprecation = None)
                       ),
+                      attributes = Nil),
+                    Operation(
+                      method = Delete,
+                      path = "/pets/:status",
+                      description = Some("delete pets by status - as a path param"),
+                      deprecation = None,
+                      body = None,
+                      parameters = Seq(Parameter(
+                        name = "status",
+                        `type` = "PetStatusDeletePath",
+                        location = Path,
+                        description = None,
+                        deprecation = None,
+                        required = true,
+                        default = None,
+                        minimum = None,
+                        maximum = None,
+                        example = None)
+                      ),
+                      responses = Seq(
+                        Response(
+                          code = ResponseCodeInt(204),
+                          `type` = "unit",
+                          description = Some("pets deleted - no response body content"),
+                          deprecation = None),
+                        Response(
+                          code = ResponseCodeOption.Default,
+                          `type` = "Error",
+                          description = Some("unexpected error"),
+                          deprecation = None)
+                      ),
                       attributes = Nil)
                   ),
                   attributes = Seq())
                 )
 
-              service.enums.size should be(3)
+              service.enums.size should be(4)
               checkEnum(service.enums.find(_.name == "PetStatus").get,
                 Enum(
                   name = "PetStatus",
@@ -229,6 +260,18 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                 Enum(
                   name = "PetStatusGetPath",
                   plural = "PetStatusGetPaths",
+                  description = None,
+                  deprecation = None,
+                  values = Seq(
+                    EnumValue(name = "available", description = None, deprecation = None, attributes = Seq()),
+                    EnumValue(name = "pending", description = None, deprecation = None, attributes = Seq()),
+                    EnumValue(name = "sold", description = None, deprecation = None, attributes = Seq())),
+                  attributes = Seq()
+                ))
+              checkEnum(service.enums.find(_.name == "PetStatusDeletePath").get,
+                Enum(
+                  name = "PetStatusDeletePath",
+                  plural = "PetStatusDeletePaths",
                   description = None,
                   deprecation = None,
                   values = Seq(


### PR DESCRIPTION
* operations with no 200 response: can't determine the resource name to properly build a name for the enum type;
* trying to find the model name by URL (see [here](https://github.com/mbryzek/apidoc/blob/master/swagger/src/main/scala/me/apidoc/swagger/translators/Parameter.scala#L53)) seems not robust enough;
* camel case not kept in the generated enum type name when the model name is composed by multiple words: e.g. ReservationResponse --> ReservationresponseBannerPostPath