### PR TITLE
On import, keep Swagger specific data as Apidoc attributes.

### DIFF
--- a/api/test/lib/OriginalUtilSpec.scala
+++ b/api/test/lib/OriginalUtilSpec.scala
@@ -27,7 +27,7 @@ class OriginalUtilSpec extends FunSpec with ShouldMatchers {
     }
 
     it("swaggerJson") {
-      OriginalUtil.guessType(TestHelper.readFile("../swagger/src/test/resources/petstore-with-external-docs.json")) should be(Some(OriginalType.SwaggerJson))
+      OriginalUtil.guessType(TestHelper.readFile("../swagger/src/test/resources/petstore-external-docs-example-security.json")) should be(Some(OriginalType.SwaggerJson))
     }
 
     it("avroIdl") {

--- a/swagger/src/main/scala/me/apidoc/swagger/Parser.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/Parser.scala
@@ -1,18 +1,17 @@
 package me.apidoc.swagger
 
-import translators.Resolver
-import lib.{ServiceConfiguration, Text, UrlKey}
-import io.swagger.parser.SwaggerParser
-import io.swagger.models.{ComposedModel, ModelImpl, RefModel, Swagger}
 import java.io.File
 
-import scala.collection.JavaConversions._
-import collection.JavaConverters._
 import com.bryzek.apidoc.spec.v0.models._
-import io.swagger.models.parameters.{AbstractSerializableParameter, PathParameter, QueryParameter}
+import io.swagger.models.parameters.AbstractSerializableParameter
+import io.swagger.models.properties.{ArrayProperty, RefProperty}
+import io.swagger.models.{ComposedModel, ModelImpl, RefModel, Swagger}
+import io.swagger.parser.SwaggerParser
+import lib.{ServiceConfiguration, Text, UrlKey}
+import me.apidoc.swagger.translators.Resolver
 
 import scala.annotation.tailrec
-import io.swagger.models.properties.{ArrayProperty, RefProperty, StringProperty}
+import scala.collection.JavaConversions._
 
 case class Parser(config: ServiceConfiguration) {
 
@@ -54,7 +53,14 @@ case class Parser(config: ServiceConfiguration) {
       models = specModels,
       imports = Nil,
       headers = Nil,
-      resources = translators.Resource.mergeAll(resourcesAndParamEnums._1)
+      resources = translators.Resource.mergeAll(resourcesAndParamEnums._1),
+      attributes =
+        Seq(
+          SwaggerData(
+            externalDocs = swagger.getExternalDocs,
+            serviceSecurity = swagger.getSecurity,
+            securityDefinitions = swagger.getSecurityDefinitions).toAttribute)
+          .flatten
     )
   }
 

--- a/swagger/src/main/scala/me/apidoc/swagger/SwaggerData.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/SwaggerData.scala
@@ -1,0 +1,56 @@
+package me.apidoc.swagger
+
+import com.bryzek.apidoc.spec.v0.models.Attribute
+import io.swagger.models.auth.SecuritySchemeDefinition
+import io.swagger.models.{ExternalDocs, SecurityRequirement}
+import me.apidoc.swagger.SwaggerData._
+import play.api.libs.json.JsObject
+
+case class SwaggerData(
+                        externalDocs: ExternalDocs = null,
+                        serviceSecurity: java.util.List[SecurityRequirement]  = null,
+                        operationSecurity: java.util.List[java.util.Map[String, java.util.List[String]]] = null,
+                        securityDefinitions: java.util.Map[String, SecuritySchemeDefinition] = null,
+                        example: Object = null) {
+
+  def toAttribute: Option[Attribute] = {
+    val jsObjFields =
+      Seq(
+        Option(externalDocs).map { externalDocs =>
+          (ExternalDocsKeyName, Util.toJsValue(externalDocs))
+        },
+        Option(serviceSecurity).flatMap { serviceSecurity =>
+          if(serviceSecurity.isEmpty) None else Some((SecurityKeyName, Util.toJsValue(serviceSecurity)))
+        },
+        Option(operationSecurity).flatMap { operationSecurity =>
+          if(operationSecurity.isEmpty) None else Some((SecurityKeyName, Util.toJsValue(operationSecurity)))
+        },
+        Option(securityDefinitions).flatMap { securityDefinitions =>
+          if(securityDefinitions.isEmpty) None else Some((SecurityDefinitionsKeyName, Util.toJsValue(securityDefinitions)))
+        },
+        Option(example).map { example =>
+          (ExampleKeyName, Util.toJsValue(example))
+        }
+      ).flatten
+
+    if(jsObjFields.isEmpty){
+      None
+    } else {
+      Some(Attribute(
+        name = AttributeName,
+        value = JsObject(jsObjFields),
+        description = Some(AttributeDescription),
+        deprecation = None))
+    }
+  }
+}
+
+object SwaggerData {
+  val AttributeName = "swagger"
+  val AttributeDescription = "Swagger-specific data"
+
+  val ExternalDocsKeyName = "externalDocs"
+  val SecurityKeyName = "security"
+  val SecurityDefinitionsKeyName = "securityDefinitions"
+  val ExampleKeyName = "example"
+}

--- a/swagger/src/main/scala/me/apidoc/swagger/Util.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/Util.scala
@@ -7,8 +7,10 @@ import java.nio.charset.StandardCharsets
 import java.io.File
 import java.util.UUID
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.{models => swaggermodels}
 import io.swagger.models.{parameters => swaggerparams, properties => swaggerproperties}
+import play.api.libs.json.{JsValue, Json}
 
 object Util {
 
@@ -149,4 +151,15 @@ object Util {
 
   def retrieveMethod(operation: swaggermodels.Operation, path: swaggermodels.Path): Option[swaggermodels.HttpMethod] =
     path.getOperationMap().find(_._2 == operation).map(_._1)
+
+  /*
+   * Useful to serialize (with Jackson) Java objects from Swagger parser
+   */
+  val JacksonSerializer = new ObjectMapper() //it's thread-safe
+  def toJsonString(jsonJavaModel: java.lang.Object): String = JacksonSerializer.writeValueAsString(jsonJavaModel)
+
+  /*
+   * Transforms a Java JSON model into the corresponding PlayJson JsValue
+   */
+  def toJsValue(jsonJavaModel: java.lang.Object): JsValue = Json.parse(toJsonString(jsonJavaModel))
 }

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Model.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Model.scala
@@ -1,10 +1,10 @@
 package me.apidoc.swagger.translators
 
 import com.bryzek.apidoc.spec.v0.models.EnumValue
-import lib.Text
-import me.apidoc.swagger.Util
 import com.bryzek.apidoc.spec.v0.{models => apidoc}
 import io.swagger.{models => swagger}
+import lib.Text
+import me.apidoc.swagger.{SwaggerData, Util}
 
 object Model {
 
@@ -40,7 +40,13 @@ object Model {
           deprecation = None,
           fields = Util.toMap(m.getProperties).map {
             case (key, prop) => Field(resolver, name, key, prop)
-          }.toSeq
+          }.toSeq,
+          attributes =
+            Seq(
+              SwaggerData(
+                externalDocs = m.getExternalDocs,
+                example = m.getExample).toAttribute)
+              .flatten
         )), enums(m, name))
     }
   }

--- a/swagger/src/main/scala/me/apidoc/swagger/translators/Operation.scala
+++ b/swagger/src/main/scala/me/apidoc/swagger/translators/Operation.scala
@@ -1,9 +1,11 @@
 package me.apidoc.swagger.translators
 
-import me.apidoc.swagger.Util
-import com.bryzek.apidoc.spec.v0.{ models => apidoc }
-import io.swagger.{ models => swagger }
+import com.bryzek.apidoc.spec.v0.{models => apidoc}
 import io.swagger.models.parameters.BodyParameter
+import io.swagger.{models => swagger}
+import me.apidoc.swagger.{SwaggerData, Util}
+
+import scala.collection.JavaConverters._
 
 object Operation {
 
@@ -57,7 +59,13 @@ object Operation {
       parameters = parameters,
       responses = Util.toMap(op.getResponses).map {
         case (code, swaggerResponse) => Response(resolver, code, swaggerResponse)
-      }.toSeq
+      }.toSeq,
+      attributes =
+        Seq(
+          SwaggerData(
+            externalDocs = op.getExternalDocs,
+            operationSecurity = op.getSecurity).toAttribute
+        ).flatten
     )
   }
 

--- a/swagger/src/test/resources/petstore-external-docs-example-security.json
+++ b/swagger/src/test/resources/petstore-external-docs-example-security.json
@@ -30,6 +30,21 @@
   "produces": [
     "application/json"
   ],
+  "securityDefinitions": {
+    "read": {
+      "type": "basic",
+      "description": "Security def for read operations"
+    },
+    "write": {
+      "type": "basic",
+      "description": "Security def for write operations"
+    }
+  },
+  "security": [
+    {
+      "read": []
+    }
+  ],
   "paths": {
     "/pets": {
       "get": {
@@ -89,6 +104,11 @@
         "operationId": "addPet",
         "produces": [
           "application/json"
+        ],
+        "security":[
+          {
+            "write": []
+          }
         ],
         "parameters": [
           {
@@ -155,6 +175,11 @@
       "delete": {
         "description": "deletes a single pet based on the ID supplied",
         "operationId": "deletePet",
+        "security":[
+          {
+            "write": []
+          }
+        ],
         "parameters": [
           {
             "name": "id",
@@ -204,12 +229,16 @@
         "tag": {
           "type": "string"
         }
+      },
+      "example": {
+        "id": "123",
+        "name": "Storm"
       }
     },
     "newPet": {
       "allOf": [
         {
-          "$ref": "pet"
+          "$ref": "#/definitions/pet"
         },
         {
           "required": [

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerDataSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerDataSpec.scala
@@ -1,0 +1,33 @@
+package me.apidoc.swagger
+
+import java.util
+
+import com.bryzek.apidoc.spec.v0.models.Attribute
+import io.swagger.models.SecurityRequirement
+import io.swagger.models.auth.SecuritySchemeDefinition
+import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.{JsObject, JsString}
+
+class SwaggerDataSpec extends FunSpec with Matchers {
+
+  it("all data points empty/null") {
+    SwaggerData().toAttribute should be (None)
+    SwaggerData(
+      serviceSecurity = new util.ArrayList[SecurityRequirement](),
+      operationSecurity = new util.ArrayList[util.Map[String, util.List[String]]](),
+      securityDefinitions = new util.HashMap[String, SecuritySchemeDefinition]()
+    ).toAttribute should be (None)
+  }
+
+  it("one data point present") {
+    SwaggerData(
+      example = "Example object"
+    ).toAttribute should be(
+      Some( Attribute(
+        name = SwaggerData.AttributeName,
+        value = JsObject(Seq(
+          ("example", JsString("Example object")))),
+        description = Some(SwaggerData.AttributeDescription)
+      )))
+  }
+}

--- a/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/SwaggerServiceValidatorSpec.scala
@@ -5,6 +5,7 @@ import com.bryzek.apidoc.spec.v0.models.ParameterLocation.{Path, Query}
 import com.bryzek.apidoc.spec.v0.models.{EnumValue, _}
 import lib.ServiceConfiguration
 import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.{JsArray, JsNull, JsObject, JsString}
 
 class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
   private val resourcesDir = "swagger/src/test/resources/"
@@ -59,6 +60,7 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
               service.baseUrl should be(Some("http://petstore.swagger.wordnik.com/api"))
               service.headers should be(Seq.empty)
               service.imports should be(Seq.empty)
+              service.attributes should be (Seq.empty)
 
               service.models.map(_.name).sorted should be(Seq("Error", "Pet"))
               checkModel(
@@ -304,6 +306,7 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
               service.baseUrl should be(Some("http://petstore.swagger.wordnik.com/api"))
               service.headers should be(Seq.empty)
               service.imports should be(Seq.empty)
+              service.attributes should be(Seq.empty)
 
               service.models.map(_.name).sorted should be(Seq("Accessory", "Error", "Pet"))
 
@@ -436,7 +439,7 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                           description = Some("unexpected error"),
                           deprecation = None)
                       ),
-                      attributes = Nil),
+                      attributes =  Seq()),
                     Operation(
                       method = Get,
                       path = "/pets/:status",
@@ -514,8 +517,8 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
       }
     }
 
-    it("should parse petstore-with-external-docs.json") {
-      val files = Seq("petstore-with-external-docs.json")
+    it("should parse petstore-external-docs-example-security.json") {
+      val files = Seq("petstore-external-docs-example-security.json")
       files.foreach {
         filename =>
           val path = resourcesDir + filename
@@ -536,6 +539,29 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
               service.imports should be(Seq.empty)
               service.enums should be(Seq.empty)
               service.models.map(_.name).sorted should be(Seq("errorModel", "newPet", "pet"))
+              service.attributes should be (
+                Seq(Attribute(
+                  name = SwaggerData.AttributeName,
+                  description = Some(SwaggerData.AttributeDescription),
+                  value = JsObject(Seq(
+                    ("externalDocs", JsObject(Seq(
+                      ("description", JsString("find more info here")),
+                      ("url", JsString("https://helloreverb.com/about"))))),
+                    ("securityDefinitions", JsObject(Seq(
+                      ("read", JsObject(Seq(
+                        ("type", JsString("basic")),
+                        ("description", JsString("Security def for read operations"))
+                      ))),
+                      ("write", JsObject(Seq(
+                        ("type", JsString("basic")),
+                        ("description", JsString("Security def for write operations"))
+                      )))))),
+                    ("security", JsArray(Seq(
+                      JsObject(Seq(
+                        ("scopes", JsNull),
+                        ("read", JsArray())
+                      )))))
+                  )))))
 
               checkModel(
                 service.models.find(_.name == "pet").get,
@@ -564,7 +590,17 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                       `type` = "string",
                       required = false
                     )
-                  )
+                  ),
+                  attributes = Seq(Attribute(
+                    name = SwaggerData.AttributeName,
+                    description = Some(SwaggerData.AttributeDescription),
+                    value = JsObject(Seq(
+                      ("externalDocs", JsObject(Seq(
+                        ("description", JsString("find more info here")),
+                        ("url", JsString("https://helloreverb.com/about"))))),
+                      ("example", JsObject(Seq(
+                        ("id", JsString("123")),
+                        ("name", JsString("Storm")))))))))
                 )
               )
 
@@ -595,7 +631,17 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                       `type` = "string",
                       required = false
                     )
-                  )
+                  ),
+                  attributes = Seq(Attribute(
+                    name = SwaggerData.AttributeName,
+                    description = Some(SwaggerData.AttributeDescription),
+                    value = JsObject(Seq(
+                      ("externalDocs", JsObject(Seq(
+                        ("description", JsString("find more info here")),
+                        ("url", JsString("https://helloreverb.com/about"))))),
+                      ("example", JsObject(Seq(
+                        ("id", JsString("123")),
+                        ("name", JsString("Storm")))))))))
                 )
               )
 
@@ -650,6 +696,19 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                         }
                       }
 
+                      println(s"   attributes:")
+                      op.attributes match {
+                        case Nil | Seq() => {
+                          println("    none")
+                        }
+                        case attributes => {
+                          attributes.foreach {
+                            a =>
+                              println(s"    ${a.name}: ${a.value}")
+                          }
+                        }
+                      }
+
                       println(s"   responses:")
                       op.responses.foreach {
                         r =>
@@ -684,6 +743,14 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
               service.imports should be(Seq.empty)
               service.enums should be(Seq.empty)
               service.models.map(_.name).sorted should be(Seq("errorModel", "newPet", "pet"))
+              service.attributes should be (
+                Seq(Attribute(
+                  name = SwaggerData.AttributeName,
+                  description = Some(SwaggerData.AttributeDescription),
+                  value = JsObject(Seq(
+                    ("externalDocs", JsObject(Seq(
+                      ("description", JsString("find more info here")),
+                      ("url", JsString("https://helloreverb.com/about"))))))))))
 
               checkModel(
                 service.models.find(_.name == "pet").get,
@@ -707,7 +774,14 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                       `type` = "string",
                       required = false
                     )
-                  )
+                  ),
+                  attributes = Seq(Attribute(
+                    name = SwaggerData.AttributeName,
+                    description = Some(SwaggerData.AttributeDescription),
+                    value = JsObject(Seq(
+                      ("externalDocs", JsObject(Seq(
+                        ("description", JsString("find more info here")),
+                        ("url", JsString("https://helloreverb.com/about")))))))))
                 )
               )
 
@@ -733,7 +807,14 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
                       `type` = "string",
                       required = false
                     )
-                  )
+                  ),
+                  attributes = Seq(Attribute(
+                    name = SwaggerData.AttributeName,
+                    description = Some(SwaggerData.AttributeDescription),
+                    value = JsObject(Seq(
+                      ("externalDocs", JsObject(Seq(
+                        ("description", JsString("find more info here")),
+                        ("url", JsString("https://helloreverb.com/about")))))))))
                 )
               )
 
@@ -832,6 +913,7 @@ class SwaggerServiceValidatorSpec extends FunSpec with Matchers {
               service.imports should be(Seq.empty)
               service.enums should be(Seq.empty)
               service.models.map(_.name).sorted should be(Seq("Body", "Error", "Inventory", "Message", "Messages", "Request", "Response", "Result", "Variant"))
+              service.imports should be(Seq.empty)
 
               checkModel(
                 service.models.find(_.name == "Response").get,

--- a/swagger/src/test/scala/me/apidoc/swagger/UtilSpec.scala
+++ b/swagger/src/test/scala/me/apidoc/swagger/UtilSpec.scala
@@ -1,6 +1,5 @@
 package me.apidoc.swagger
 
-import lib.ServiceConfiguration
 import org.scalatest.{FunSpec, Matchers}
 
 class UtilSpec extends FunSpec with Matchers {


### PR DESCRIPTION
Swagger data covered in this PR:
* `external docs`
* `security`
* `security definitions`
* `example object`

Swagger data NOT covered:
* `summary`
* `operationId`
* `tags`

Open question(s):
* should we import as attributes also `schemes`, `host`, `basePath` that are currently combined into Apidoc's *baseUrl* service property ?

Resolves #584 

Example of *api.json* obtained importing [this swagger.json file](https://github.com/fabiocognigni/apidoc/blob/584_swagger_data_attributes/swagger/src/test/resources/petstore-external-docs-example-security.json) : 
[apidoc-swagger-attribute-example.json.txt](https://github.com/mbryzek/apidoc/files/1018355/apidoc-swagger-attribute-example.json.txt)


